### PR TITLE
feat: Implement multi-tool Web Copy Studio

### DIFF
--- a/app.py
+++ b/app.py
@@ -667,25 +667,113 @@ def construct_ecommerce_prompt(name, features, tone):
     Generate the product description now.
     """
 
-def construct_webcopy_prompt(product, audience):
-    """Constructs a prompt for generating landing page copy using the AIDA framework."""
-    return f"""
-    You are a master copywriter who specializes in high-converting landing pages. Your task is to write copy for a product/service based on the AIDA (Attention, Interest, Desire, Action) framework.
+def construct_landing_page_prompt(settings=None):
+    """Constructs a prompt for generating a full landing page."""
+    if settings is None: settings = {}
 
-    **Product/Service:** {product}
-    **Target Audience:** {audience}
+    prompt = f"""
+You are an expert direct-response copywriter. Your task is to write a complete set of copy for a landing page with a single, clear goal.
 
-    **Instructions:**
-    1.  **Write for Each AIDA Stage:** Create distinct copy for each of the four stages:
-        *   `attention`: A powerful headline and sub-headline to grab the attention of the {audience}.
-        *   `interest`: Build interest by highlighting the core problems of the audience and hinting at a better way. Use bullet points or a short paragraph.
-        *   `desire`: Create desire by explaining the product's features and, more importantly, its benefits. Show the audience how their life or work will improve.
-        *   `action`: A clear and compelling call to action (CTA) that tells the user exactly what to do next (e.g., "Sign Up Now," "Get Your Free Demo").
-    2.  **Format as JSON:** Return the output as a single, valid JSON object. The keys should be the AIDA stages (`attention`, `interest`, `desire`, `action`), and the values should be the corresponding copy as a string.
-    3.  **Return Only JSON:** Do not include any preamble, commentary, or markdown formatting. Only return the raw JSON object.
+**Landing Page Details:**
+- **Product Name:** {settings.get('productName', '')}
+- **Target Audience:** {settings.get('audience', '')}
+- **Page Goal:** {settings.get('goal', '')}
+- **Primary Pain Point to Solve:** {settings.get('painPoint', '')}
+- **Tone:** {settings.get('tone', '')}
 
-    Generate the AIDA landing page copy now.
-    """
+**Key Features:**
+---
+{settings.get('features', '')}
+---
+
+**Instructions:**
+1.  **Solve the Pain Point:** All copy must focus on how the product's features solve the primary pain point for the target audience.
+2.  **Benefit-Oriented:** Do not just list features; explain the tangible benefits and outcomes for the user.
+3.  **Clear Structure:** Structure the output using the following Markdown headings: `### Headline`, `### Sub-headline`, `### Body`, and `### Call-to-Action`.
+4.  **Persuasive Body:** The Body copy should be compelling, persuasive, and directly encourage the user to achieve the page goal.
+5.  **Actionable CTA:** The Call-to-Action should be a short, punchy phrase that tells the user exactly what to do (e.g., "Get Started Free," "Claim Your Discount").
+6.  **Output:** Return only the structured copy, without any of your own commentary.
+
+Generate the landing page copy now.
+"""
+    return prompt
+
+def construct_homepage_section_prompt(settings=None):
+    """Constructs a dynamic prompt for generating a specific homepage section."""
+    if settings is None: settings = {}
+
+    section_type = settings.get('sectionType', 'hero')
+    section_map = {
+        "hero": "Hero Section",
+        "features": "Features/Benefits Section",
+        "how_it_works": "How It Works Section",
+        "faq": "FAQ Section"
+    }
+    section_name = section_map.get(section_type, "Hero Section")
+
+    prompt = f"""
+You are a specialist web copywriter. Your task is to write the copy for a specific section of a company's homepage.
+
+**Company Name:** {settings.get('companyName', '')}
+**Company One-Liner:** {settings.get('oneLiner', '')}
+**Section to Generate:** {section_name}
+
+**Key Information Provided by User:**
+---
+{settings.get('keyInfo', '')}
+---
+
+**Instructions:**
+Your output must be structured correctly for the requested section.
+"""
+
+    if section_type == 'hero':
+        prompt += """
+- **Task:** Write a powerful, attention-grabbing headline, a clear and concise sub-headline that expands on the headline, and two distinct, compelling CTA button texts.
+- **Structure:** Use the following Markdown headings for each part: `#### Headline`, `#### Sub-headline`, `#### Primary CTA`, `#### Secondary CTA`.
+"""
+    elif section_type == 'features':
+        prompt += """
+- **Task:** Write a main headline for the features section. Then, for 3-5 key features, write a short, benefit-focused title and a 1-2 sentence description for each.
+- **Structure:** Use a main `### Features Section Headline`. For each feature, use a `#### Feature Title` and a paragraph for the description.
+"""
+    elif section_type == 'how_it_works':
+        prompt += """
+- **Task:** Write a main headline for this section. Then, write copy for 3-4 simple steps that explain how the service works.
+- **Structure:** Use a main `### How It Works Headline`. For each step, use a `#### Step X: [Step Title]` heading followed by a short descriptive paragraph.
+"""
+    elif section_type == 'faq':
+        prompt += """
+- **Task:** Write a main headline for the FAQ section. Then, based on the user's key information, write 4-5 questions and their corresponding clear, concise answers.
+- **Structure:** Use a main `### FAQ Section Headline`. For each question, use a `#### Question:` heading and a paragraph for the answer.
+"""
+
+    prompt += "\nReturn only the generated copy in the requested structure, without any of your own commentary."
+    return prompt
+
+def construct_usp_prompt(settings=None):
+    """Constructs a prompt for generating a Value Proposition and USP."""
+    if settings is None: settings = {}
+
+    prompt = f"""
+You are a senior brand strategist. Your task is to analyze the following product information and generate a powerful Value Proposition and a list of Unique Selling Propositions (USPs).
+
+**Product Information:**
+- **Product Description:** {settings.get('productDesc', '')}
+- **Target Customer:** {settings.get('customer', '')}
+- **Key Differentiators:** {settings.get('differentiators', '')}
+- **Competitors:** {settings.get('competitors', 'Not specified')}
+
+**Instructions:**
+1.  **Analyze the Data:** Carefully consider how the product's features and differentiators appeal to the target customer, especially in contrast to the competitors.
+2.  **Generate Value Proposition:** Create a single, clear, and compelling sentence that explains the core benefit the product provides to the customer. This should be customer-centric and outcome-focused.
+3.  **Generate USPs:** Create a list of 3-5 concise, memorable, and powerful statements that highlight the key differentiators. These are the specific, unique reasons a customer should choose this product over others.
+4.  **Structure the Output:** Use the following Markdown headings: `### Value Proposition` and `### Unique Selling Propositions (USPs)`. List the USPs as a bulleted list.
+5.  **Output:** Return only the generated propositions, without any of your own commentary.
+
+Generate the Value Proposition and USPs now.
+"""
+    return prompt
 
 def construct_press_release_prompt(announcement, company):
     """Constructs a prompt for generating a press release."""
@@ -1833,52 +1921,55 @@ def generate_ecommerce():
 @app.route('/api/v1/generate/webcopy', methods=['POST'])
 @login_required
 def generate_webcopy():
-    """Generates landing page copy using the AIDA framework."""
+    """Handles various web copy generation requests."""
     if not CLIENT:
         return jsonify({"error": "AI service is not available."}), 503
 
     data = request.get_json()
-    product = data.get("product")
-    audience = data.get("audience")
+    tool = data.get("tool")
+    settings = data.get("settings", {})
     chat_session_id = data.get("chat_session_id")
 
-    if not all([product, audience]):
-        return jsonify({"error": "Missing required fields."}), 400
+    if not tool:
+        return jsonify({"error": "Missing required field: tool."}), 400
 
     if not check_monthly_word_quota(current_user):
         return jsonify({"error": f"You've reached your monthly word limit."}), 403
 
-    full_prompt = construct_webcopy_prompt(product, audience)
+    # Route to the correct prompt constructor
+    if tool == 'landing_page':
+        full_prompt = construct_landing_page_prompt(settings)
+        session_title = f"LP: {settings.get('productName', 'New Page')[:30]}"
+    elif tool == 'homepage_section':
+        full_prompt = construct_homepage_section_prompt(settings)
+        session_title = f"Homepage: {settings.get('sectionType', 'New Section')[:30]}"
+    elif tool == 'usp':
+        full_prompt = construct_usp_prompt(settings)
+        session_title = f"USP for: {settings.get('productDesc', 'New Product')[:30]}"
+    else:
+        return jsonify({"error": f"Unknown tool: {tool}"}), 400
+
     try:
         response = CLIENT.generate_content(contents=full_prompt)
-        raw_text = response.candidates[0].content.parts[0].text
+        result_text = response.candidates[0].content.parts[0].text
 
-        # Clean and parse the JSON response
-        clean_text = re.sub(r'^```json\s*|\s*```$', '', raw_text.strip())
-        webcopy_json = json.loads(clean_text)
-
-        # Save to chat history
         if not chat_session_id:
             chat_session_id = f"chat_{int(datetime.utcnow().timestamp())}_{current_user.id}"
 
-        user_message = f"Generate AIDA landing page copy for '{product}' targeting {audience}."
+        user_message = json.dumps({"tool": tool, "settings": settings})
         messages = [
             {"content": user_message, "isUser": True, "id": f"msg_{int(datetime.utcnow().timestamp())}_user"},
-            {"content": raw_text, "isUser": False, "id": f"msg_{int(datetime.utcnow().timestamp())}_ai"}
+            {"content": result_text, "isUser": False, "id": f"msg_{int(datetime.utcnow().timestamp())}_ai"}
         ]
 
-        session_title = f"Web Copy for {product}"
-        save_chat_session_to_db(current_user.id, chat_session_id, session_title, messages, raw_text, studio_type='WEBCOPY')
+        save_chat_session_to_db(current_user.id, chat_session_id, session_title, messages, result_text, studio_type='WEBCOPY')
 
         return jsonify({
-            "webcopy": webcopy_json,
+            "result": result_text,
             "chat_session_id": chat_session_id
         })
-    except json.JSONDecodeError:
-        logger.error(f"Web copy JSON parsing error. Raw text: {raw_text}")
-        return jsonify({"error": "Failed to parse the web copy data from the AI. Please try again."}), 500
     except Exception as e:
-        logger.error(f"Web copy generation error: {e}")
+        logger.error(f"Web copy generation error for tool {tool}: {e}")
         return jsonify({"error": f"An unexpected error occurred: {str(e)}"}), 500
 
 @app.route('/api/v1/generate/business', methods=['POST'])

--- a/templates/webcopy_studio.html
+++ b/templates/webcopy_studio.html
@@ -4,6 +4,35 @@
 
 {% block studio_head_css %}
 <style>
+    /* Custom Tab Styles from Brainstorming Studio */
+    .tabs {
+        display: flex;
+        border-bottom: 1px solid var(--outline);
+        margin-bottom: 20px;
+    }
+    .tab-button {
+        padding: 10px 20px;
+        cursor: pointer;
+        border: none;
+        background: none;
+        font-family: inherit;
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--on-surface-variant);
+        border-bottom: 2px solid transparent;
+        margin-bottom: -1px;
+    }
+    .tab-button.active {
+        color: var(--primary-blue);
+        border-bottom-color: var(--primary-blue);
+    }
+    .tab-content {
+        display: none;
+    }
+    .tab-content.active {
+        display: block;
+    }
+    /* General Studio Styles */
     .output-card {
         background: var(--surface-variant);
         border: 1px solid var(--outline);
@@ -11,17 +40,8 @@
         padding: 16px;
         margin-top: 16px;
     }
-    .output-card h4 {
-        margin-top: 0;
-        margin-bottom: 12px;
-        font-weight: 500;
-        text-transform: capitalize;
-    }
     .output-content {
         white-space: pre-wrap;
-        font-family: inherit;
-        font-size: 14px;
-        color: var(--on-surface);
     }
     .spinner {
         width: 16px;
@@ -39,20 +59,55 @@
 {% endblock %}
 
 {% block studio_title %}Web Copy Studio{% endblock %}
-{% block studio_description %}Craft landing page copy, ad copy, and more using proven frameworks.{% endblock %}
+{% block studio_description %}Craft foundational, persuasive copy for your website.{% endblock %}
 
 {% block studio_inputs %}
-<div class="form-group">
-    <label for="webcopy-product">Product/Service Name</label>
-    <input type="text" id="webcopy-product" class="form-control" placeholder="e.g., InkDrive AI Writing Assistant">
+<div class="tabs">
+    <button class="tab-button active" data-tab="landing-page">Landing Page</button>
+    <button class="tab-button" data-tab="homepage-section">Homepage Section</button>
+    <button class="tab-button" data-tab="usp">Value Proposition</button>
 </div>
-<div class="form-group">
-    <label for="webcopy-audience">Target Audience</label>
-    <input type="text" id="webcopy-audience" class="form-control" placeholder="e.g., Content creators, marketers, authors">
+
+<!-- Landing Page Writer Tab -->
+<div id="landing-page" class="tab-content active">
+    <div class="form-group"><label for="lp-product-name">Product Name</label><input type="text" id="lp-product-name" class="form-control" placeholder="e.g., Quantum CRM"></div>
+    <div class="form-group"><label for="lp-audience">Target Audience</label><input type="text" id="lp-audience" class="form-control" placeholder="e.g., Small business owners"></div>
+    <div class="form-group"><label for="lp-goal">Page Goal</label><input type="text" id="lp-goal" class="form-control" placeholder="e.g., Get users to sign up for a free trial"></div>
+    <div class="form-group"><label for="lp-features">Features (one per line)</label><textarea id="lp-features" class="form-control" rows="3" placeholder="e.g., AI-powered contact sorting&#10;Automated email follow-ups"></textarea></div>
+    <div class="form-group"><label for="lp-pain-point">Primary Pain Point to Solve</label><input type="text" id="lp-pain-point" class="form-control" placeholder="e.g., Wasting time on manual data entry"></div>
+    <div class="form-group"><label for="lp-tone">Tone</label><input type="text" id="lp-tone" class="form-control" placeholder="e.g., Professional and efficient"></div>
 </div>
-<button id="generateWebcopyBtn" class="btn btn-primary" style="width: 100%;">
+
+<!-- Homepage Section Writer Tab -->
+<div id="homepage-section" class="tab-content">
+    <div class="form-group"><label for="hs-company-name">Company Name</label><input type="text" id="hs-company-name" class="form-control" placeholder="e.g., Innovate Inc."></div>
+    <div class="form-group"><label for="hs-one-liner">Company One-Liner</label><input type="text" id="hs-one-liner" class="form-control" placeholder="e.g., We build software that simplifies your workflow."></div>
+    <div class="form-group">
+        <label for="hs-section-type">Section to Generate</label>
+        <select id="hs-section-type" class="form-control">
+            <option value="hero" selected>Hero Section</option>
+            <option value="features">Features/Benefits Section</option>
+            <option value="how_it_works">How It Works Section</option>
+            <option value="faq">FAQ Section</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label for="hs-key-info" id="hs-key-info-label">Key Information for Hero Section</label>
+        <textarea id="hs-key-info" class="form-control" rows="3" placeholder="e.g., List the main value proposition and desired call to action."></textarea>
+    </div>
+</div>
+
+<!-- Value Proposition & USP Generator Tab -->
+<div id="usp" class="tab-content">
+    <div class="form-group"><label for="usp-product-desc">Product Description</label><textarea id="usp-product-desc" class="form-control" rows="3" placeholder="Describe what your product is and what it does."></textarea></div>
+    <div class="form-group"><label for="usp-customer">Target Customer</label><input type="text" id="usp-customer" class="form-control" placeholder="e.g., Freelancers who need simple invoicing."></div>
+    <div class="form-group"><label for="usp-differentiators">Key Differentiators</label><textarea id="usp-differentiators" class="form-control" rows="2" placeholder="What makes you unique? e.g., Unbeatable price, lifetime support"></textarea></div>
+    <div class="form-group"><label for="usp-competitors">Competitors (Optional)</label><input type="text" id="usp-competitors" class="form-control" placeholder="e.g., FreshBooks, Wave"></div>
+</div>
+
+<button id="generateBtn" class="btn btn-primary mt-3" style="width: 100%;">
     <span class="material-symbols-outlined">web</span>
-    Generate Landing Page Copy
+    Generate Web Copy
 </button>
 {% endblock %}
 
@@ -71,97 +126,116 @@
 </script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const generateBtn = document.getElementById('generateWebcopyBtn');
+    const generateBtn = document.getElementById('generateBtn');
     const outputDisplay = document.getElementById('webcopy-output-display');
+    const tabs = document.querySelectorAll('.tab-button');
+    const tabContents = document.querySelectorAll('.tab-content');
+    const sectionTypeSelect = document.getElementById('hs-section-type');
+    const keyInfoLabel = document.getElementById('hs-key-info-label');
+    const keyInfoTextarea = document.getElementById('hs-key-info');
     let webcopyChatSessionId = null;
 
+    // --- Tab Switching Logic ---
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            tabs.forEach(t => t.classList.remove('active'));
+            tabContents.forEach(c => c.classList.remove('active'));
+            tab.classList.add('active');
+            document.getElementById(tab.dataset.tab).classList.add('active');
+        });
+    });
+
+    // --- Dynamic UI for Homepage Section Tool ---
+    const keyInfoPlaceholders = {
+        hero: "Provide the main value proposition and desired calls to action (e.g., 'Sign Up Free', 'Learn More').",
+        features: "List 3-5 key features and their primary benefit to the user.",
+        how_it_works: "Outline the simple, 3-4 steps a user takes to get value from your product.",
+        faq: "List 4-5 common questions a potential customer might have."
+    };
+    sectionTypeSelect?.addEventListener('change', function() {
+        const selectedType = this.value;
+        keyInfoLabel.textContent = `Key Information for ${this.options[this.selectedIndex].text}`;
+        keyInfoTextarea.placeholder = keyInfoPlaceholders[selectedType] || '';
+    });
+
+    // --- Main Generate Function ---
     if (generateBtn) {
         generateBtn.addEventListener('click', async () => {
-            const product = document.getElementById('webcopy-product').value;
-            const audience = document.getElementById('webcopy-audience').value;
+            const tool = document.querySelector('.tab-button.active')?.dataset.tab;
+            if (!tool) return alert('Error: Could not find active tool.');
 
-            if (!product.trim() || !audience.trim()) {
-                alert('Please enter a product/service and target audience.');
-                return;
-            }
+            const settings = gatherInputs(tool);
+            if (!settings) return alert('Please fill in all required fields for the selected tool.');
 
-            generateBtn.disabled = true;
-            generateBtn.innerHTML = `<span class="material-symbols-outlined">hourglass_top</span> Generating...`;
-            outputDisplay.innerHTML = `<div class="loading" style="padding: 40px; display:flex; justify-content: center; align-items: center; gap: 8px;"><div class="spinner"></div><span>Writing your landing page...</span></div>`;
-
+            showLoading();
             try {
                 const response = await fetch('/api/v1/generate/webcopy', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        product: product,
-                        audience: audience,
-                        chat_session_id: webcopyChatSessionId
-                    })
+                    body: JSON.stringify({ tool, settings, chat_session_id: webcopyChatSessionId })
                 });
                 const data = await response.json();
-
                 if (response.ok) {
                     webcopyChatSessionId = data.chat_session_id;
-                    displayWebCopy(data.webcopy);
-                    if (typeof loadChatHistory === 'function') {
-                        loadChatHistory(STUDIO_TYPE);
-                    }
+                    displayOutput(data.result);
+                    if (typeof loadChatHistory === 'function') loadChatHistory(STUDIO_TYPE);
                 } else {
-                    throw new Error(data.error || 'Failed to generate web copy');
+                    throw new Error(data.error || 'Failed to generate content');
                 }
             } catch (error) {
-                outputDisplay.innerHTML = `<div class="output-card"><p style="color: red;">Error: ${error.message}</p></div>`;
+                showError(error.message);
             } finally {
-                generateBtn.disabled = false;
-                generateBtn.innerHTML = '<span class="material-symbols-outlined">web</span> Generate Landing Page Copy';
+                resetButton();
             }
         });
     }
 
-    function displayWebCopy(copyJson) {
-        if (!copyJson) {
-            outputDisplay.innerHTML = '<div class="output-card"><p>The model did not return any copy. Please try again.</p></div>';
-            return;
+    function gatherInputs(tool) {
+        let settings = {};
+        let isValid = true;
+        if (tool === 'landing-page') {
+            settings.productName = document.getElementById('lp-product-name').value;
+            settings.audience = document.getElementById('lp-audience').value;
+            settings.goal = document.getElementById('lp-goal').value;
+            settings.features = document.getElementById('lp-features').value;
+            settings.painPoint = document.getElementById('lp-pain-point').value;
+            settings.tone = document.getElementById('lp-tone').value;
+            if (!settings.productName || !settings.audience || !settings.goal || !settings.features || !settings.painPoint) isValid = false;
+        } else if (tool === 'homepage-section') {
+            settings.companyName = document.getElementById('hs-company-name').value;
+            settings.oneLiner = document.getElementById('hs-one-liner').value;
+            settings.sectionType = document.getElementById('hs-section-type').value;
+            settings.keyInfo = document.getElementById('hs-key-info').value;
+            if (!settings.companyName || !settings.oneLiner || !settings.keyInfo) isValid = false;
+        } else if (tool === 'usp') {
+            settings.productDesc = document.getElementById('usp-product-desc').value;
+            settings.customer = document.getElementById('usp-customer').value;
+            settings.differentiators = document.getElementById('usp-differentiators').value;
+            settings.competitors = document.getElementById('usp-competitors').value;
+            if (!settings.productDesc || !settings.customer || !settings.differentiators) isValid = false;
         }
-
-        let html = '';
-        for (const section in copyJson) {
-            if (copyJson.hasOwnProperty(section)) {
-                html += `
-                    <div class="output-card">
-                        <h4>${section.replace(/_/g, ' ')}</h4>
-                        <pre class="output-content">${copyJson[section].replace(/</g, "&lt;").replace(/>/g, "&gt;")}</pre>
-                    </div>
-                `;
-            }
-        }
-        outputDisplay.innerHTML = html;
+        return isValid ? settings : null;
     }
 
-    window.loadSessionIntoView = async function(sessionId) {
-        try {
-            outputDisplay.innerHTML = `<div class="loading" style="padding: 40px; display:flex; justify-content: center; align-items: center; gap: 8px;"><div class="spinner"></div><span>Loading session...</span></div>`;
-            const response = await fetch(`/api/chat-session/${sessionId}`);
-            if (!response.ok) throw new Error('Failed to fetch session data.');
+    // --- UI Helper Functions ---
+    function showLoading() {
+        generateBtn.disabled = true;
+        generateBtn.innerHTML = `<span class="material-symbols-outlined">hourglass_top</span> Generating...`;
+        outputDisplay.innerHTML = `<div class="loading" style="padding: 40px; display:flex; justify-content: center; align-items: center; gap: 8px;"><div class="spinner"></div><span>Crafting your web copy...</span></div>`;
+    }
 
-            const session = await response.json();
-            webcopyChatSessionId = session.session_id;
+    function showError(message) {
+        outputDisplay.innerHTML = `<div class="output-card" style="color: var(--error);"><p><strong>Error:</strong> ${message}</p></div>`;
+    }
 
-            const userInput = JSON.parse(session.messages[0].content);
-            document.getElementById('webcopy-product').value = userInput.product || '';
-            document.getElementById('webcopy-audience').value = userInput.audience || '';
-            document.getElementById('generateWebcopyBtn').disabled = true;
+    function resetButton() {
+        generateBtn.disabled = false;
+        generateBtn.innerHTML = '<span class="material-symbols-outlined">web</span> Generate Web Copy';
+    }
 
-            displayWebCopy(JSON.parse(session.raw_text));
-
-            if (typeof showNotification === 'function') {
-                showNotification('Session loaded successfully!');
-            }
-
-        } catch (error) {
-            outputDisplay.innerHTML = `<div class="output-card"><p style="color: red;">Error: ${error.message}</p></div>`;
-        }
+    function displayOutput(text) {
+        if (!text) return showError('The model did not return any content. Please try again.');
+        outputDisplay.innerHTML = `<div class="output-card"><pre class="output-content">${text.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</pre></div>`;
     }
 });
 </script>


### PR DESCRIPTION
This commit introduces a new, powerful Web Copy Studio, replacing the previous simple AIDA generator. The new studio is a suite of three specialized tools for creating foundational website copy.

The new studio features a three-tab UI for:
1.  **Landing Page Writer:** Generates a complete set of landing page copy (Headline, Body, CTA) focused on a specific goal and pain point.
2.  **Homepage Section Writer:** Dynamically generates copy for different sections of a homepage (Hero, Features, FAQ, etc.).
3.  **Value Proposition & USP Generator:** Analyzes product and customer data to create a compelling value proposition and unique selling propositions.

The backend has been significantly updated with a new API endpoint (`/api/v1/generate/webcopy`) and three new prompt constructor functions (`construct_landing_page_prompt`, `construct_homepage_section_prompt`, `construct_usp_prompt`) to power the new tools. The frontend uses the project's established custom tab-switching logic for a consistent user experience.