### PR TITLE
feat: Add admin panel for studio management

### DIFF
--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -222,6 +222,13 @@
                             Articles
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.endpoint in ['admin.studios', 'admin.studio_detail'] %}active{% endif %}"
+                           href="{{ url_for('admin.studios') }}">
+                            <i class="fas fa-cogs fa-fw"></i>
+                            Studios
+                        </a>
+                    </li>
                     <li class="nav-item mt-auto">
                         <hr class="sidebar-divider my-3" style="border-color: #34495e;">
                     </li>

--- a/templates/admin/studio_detail.html
+++ b/templates/admin/studio_detail.html
@@ -1,0 +1,253 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ studio.name }} Studio Details{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <a href="{{ url_for('admin.studios') }}" class="btn btn-sm btn-outline-secondary mb-3">
+        <i class="fas fa-arrow-left"></i> Back to All Studios
+    </a>
+    <h1 class="h3 mb-2 text-gray-800">{{ studio.name }} Studio</h1>
+    <p class="mb-4">Detailed analysis of content and user activity within the {{ studio.name }} studio.</p>
+
+    <!-- Stat Cards -->
+    <div class="row">
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-primary shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                        <div class="col mr-2">
+                            <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Total Sessions</div>
+                            <div class="h5 mb-0 font-weight-bold text-gray-800">{{ studio.total_sessions | int }}</div>
+                        </div>
+                        <div class="col-auto">
+                            <i class="fas fa-comments fa-2x text-gray-300"></i>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-success shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                        <div class="col mr-2">
+                            <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Unique Users</div>
+                            <div class="h5 mb-0 font-weight-bold text-gray-800">{{ studio.total_users | int }}</div>
+                        </div>
+                        <div class="col-auto">
+                            <i class="fas fa-users fa-2x text-gray-300"></i>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-info shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                        <div class="col mr-2">
+                            <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Generated Articles</div>
+                            <div class="h5 mb-0 font-weight-bold text-gray-800">{{ studio.total_articles | int }}</div>
+                        </div>
+                        <div class="col-auto">
+                            <i class="fas fa-newspaper fa-2x text-gray-300"></i>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-3 col-md-6 mb-4">
+            <div class="card border-left-warning shadow h-100 py-2">
+                <div class="card-body">
+                    <div class="row no-gutters align-items-center">
+                        <div class="col mr-2">
+                            <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">Total Words Generated</div>
+                            <div class="h5 mb-0 font-weight-bold text-gray-800">{{ studio.total_words | int }}</div>
+                        </div>
+                        <div class="col-auto">
+                            <i class="fas fa-file-word fa-2x text-gray-300"></i>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tabbed Interface -->
+    <div class="card shadow mb-4">
+        <div class="card-header py-3">
+            <ul class="nav nav-tabs card-header-tabs" id="studio-tabs" role="tablist">
+                <li class="nav-item">
+                    <a class="nav-link active" id="content-tab" data-bs-toggle="tab" href="#content" role="tab" aria-controls="content" aria-selected="true">Content & Activity</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" id="users-tab" data-bs-toggle="tab" href="#users" role="tab" aria-controls="users" aria-selected="false">Top Users</a>
+                </li>
+            </ul>
+        </div>
+        <div class="card-body">
+            <div class="tab-content" id="studio-tabs-content">
+                <!-- Content Tab -->
+                <div class="tab-pane fade show active" id="content" role="tabpanel" aria-labelledby="content-tab">
+                    <div class="d-flex justify-content-end mb-3">
+                        <form action="{{ url_for('admin.studio_detail', studio_name=studio.key) }}" method="get" class="d-none d-sm-inline-block form-inline mr-auto ml-md-3 my-2 my-md-0 mw-100 navbar-search">
+                            <div class="input-group">
+                                <input type="text" name="search" class="form-control bg-light border-0 small" placeholder="Search content or users..." value="{{ search }}">
+                                <div class="input-group-append">
+                                    <button class="btn btn-primary" type="submit">
+                                        <i class="fas fa-search fa-sm"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table table-bordered" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th>Session Title</th>
+                                    <th>User</th>
+                                    <th>Studio Type</th>
+                                    <th>Has Article?</th>
+                                    <th>Date</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for session in content.items %}
+                                <tr>
+                                    <td>{{ session.title | truncate(60) }}</td>
+                                    <td>
+                                        <a href="{{ url_for('admin.user_detail', user_id=session.user.id) }}">
+                                            {{ session.user.name }}
+                                        </a>
+                                        <br>
+                                        <small>{{ session.user.email }}</small>
+                                    </td>
+                                    <td><span class="badge bg-secondary">{{ session.studio_type }}</span></td>
+                                    <td>
+                                        {% if session.articles.first() %}
+                                            <span class="badge bg-success">Yes</span>
+                                        {% else %}
+                                            <span class="badge bg-light text-dark">No</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ session.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+                                    <td>
+                                        {% if session.articles.first() %}
+                                        <a href="{{ url_for('admin.article_detail', article_id=session.articles.first().id) }}" class="btn btn-info btn-sm" title="View Article">
+                                            <i class="fas fa-eye"></i>
+                                        </a>
+                                        {% endif %}
+                                        <button class="btn btn-danger btn-sm delete-session-btn" data-session-id="{{ session.id }}" title="Delete Session">
+                                            <i class="fas fa-trash"></i>
+                                        </button>
+                                    </td>
+                                </tr>
+                                {% else %}
+                                <tr>
+                                    <td colspan="6" class="text-center">No content found for this studio.</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <!-- Pagination -->
+                    {% if content.pages > 1 %}
+                    <nav>
+                        <ul class="pagination justify-content-center">
+                            <li class="page-item {% if not content.has_prev %}disabled{% endif %}">
+                                <a class="page-link" href="{{ url_for('admin.studio_detail', studio_name=studio.key, page=content.prev_num, search=search) }}">Previous</a>
+                            </li>
+                            {% for page_num in content.iter_pages() %}
+                            <li class="page-item {% if page_num == content.page %}active{% endif %}">
+                                <a class="page-link" href="{{ url_for('admin.studio_detail', studio_name=studio.key, page=page_num, search=search) }}">{{ page_num }}</a>
+                            </li>
+                            {% endfor %}
+                            <li class="page-item {% if not content.has_next %}disabled{% endif %}">
+                                <a class="page-link" href="{{ url_for('admin.studio_detail', studio_name=studio.key, page=content.next_num, search=search) }}">Next</a>
+                            </li>
+                        </ul>
+                    </nav>
+                    {% endif %}
+
+                </div>
+
+                <!-- Users Tab -->
+                <div class="tab-pane fade" id="users" role="tabpanel" aria-labelledby="users-tab">
+                    <div class="table-responsive">
+                        <table class="table table-bordered" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th>Rank</th>
+                                    <th>User</th>
+                                    <th>Email</th>
+                                    <th>Sessions in Studio</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for user, session_count in users %}
+                                <tr>
+                                    <td>{{ loop.index }}</td>
+                                    <td>{{ user.name }}</td>
+                                    <td>{{ user.email }}</td>
+                                    <td>{{ session_count }}</td>
+                                    <td>
+                                        <a href="{{ url_for('admin.user_detail', user_id=user.id) }}" class="btn btn-info btn-sm">
+                                            <i class="fas fa-user"></i> View Profile
+                                        </a>
+                                    </td>
+                                </tr>
+                                {% else %}
+                                <tr>
+                                    <td colspan="5" class="text-center">No users found for this studio.</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const deleteButtons = document.querySelectorAll('.delete-session-btn');
+    deleteButtons.forEach(button => {
+        button.addEventListener('click', function(e) {
+            const sessionId = e.currentTarget.dataset.sessionId;
+            if (confirm('Are you sure you want to delete this session and all its associated articles? This action cannot be undone.')) {
+                fetch(`/admin/api/sessions/${sessionId}/delete`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        // Remove the table row on success
+                        e.currentTarget.closest('tr').remove();
+                        alert(data.message);
+                    } else {
+                        alert('Error: ' + data.error);
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('An unexpected error occurred.');
+                });
+            }
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/templates/admin/studios.html
+++ b/templates/admin/studios.html
@@ -1,0 +1,49 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Studio Management{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <h1 class="h3 mb-4 text-gray-800">Studio Management</h1>
+
+    <div class="card shadow mb-4">
+        <div class="card-header py-3">
+            <h6 class="m-0 font-weight-bold text-primary">All Studios</h6>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+                    <thead>
+                        <tr>
+                            <th>Studio Name</th>
+                            <th>Total Sessions</th>
+                            <th>Unique Users</th>
+                            <th>Generated Articles</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for studio in studio_stats %}
+                        <tr>
+                            <td>{{ studio.name }}</td>
+                            <td>{{ studio.total_sessions }}</td>
+                            <td>{{ studio.total_users }}</td>
+                            <td>{{ studio.total_articles }}</td>
+                            <td>
+                                <a href="{{ url_for('admin.studio_detail', studio_name=studio.key) }}" class="btn btn-info btn-sm">
+                                    <i class="fas fa-eye"></i> View
+                                </a>
+                            </td>
+                        </tr>
+                        {% else %}
+                        <tr>
+                            <td colspan="5" class="text-center">No studio data available.</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new section in the admin panel for managing and monitoring the 10 content studios.

The new features include:
- A main dashboard at /admin/studios that lists all studios with high-level statistics (total sessions, users, articles).
- A detailed view for each studio at /admin/studios/<studio_name> with in-depth stats and two tabs:
  - Content & Activity: A paginated and searchable list of all chat sessions and articles generated in the studio.
  - Top Users: A list of the most active users in the studio.
- Content moderation action to delete a chat session and its associated articles via a new API endpoint.