### PR TITLE
feat: Integrate Cloudflare Turnstile for auth endpoints

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cdefs%3E%3ClinearGradient id='grad' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' style='stop-color:%234285f4'/%3E%3Cstop offset='25%25' style='stop-color:%2334a853'/%3E%3Cstop offset='50%25' style='stop-color:%23fbbc05'/%3E%3Cstop offset='100%25' style='stop-color:%23ea4335'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='24' height='24' rx='6' fill='url(%23grad)'/%3E%3Ctext x='12' y='16' text-anchor='middle' fill='white' font-family='Arial, sans-serif' font-size='14' font-weight='600'%3EI%3C/text%3E%3C/svg%3E">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <style>
         :root {
             --primary-blue: #1a73e8;
@@ -322,6 +323,10 @@
                 {{ form.remember_me() }}
                 {{ form.remember_me.label() }}
             </div>
+
+            {% if not is_pull_request %}
+            <div class="cf-turnstile" data-sitekey="{{ config.CLOUDFLARE_TURNSTILE_SITE_KEY }}" data-theme="light"></div>
+            {% endif %}
 
             <button type="submit" class="auth-button">Sign In</button>
         </form>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cdefs%3E%3ClinearGradient id='grad' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' style='stop-color:%234285f4'/%3E%3Cstop offset='25%25' style='stop-color:%2334a853'/%3E%3Cstop offset='50%25' style='stop-color:%23fbbc05'/%3E%3Cstop offset='100%25' style='stop-color:%23ea4335'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='24' height='24' rx='6' fill='url(%23grad)'/%3E%3Ctext x='12' y='16' text-anchor='middle' fill='white' font-family='Arial, sans-serif' font-size='14' font-weight='600'%3EI%3C/text%3E%3C/svg%3E">
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <style>
         /* Same styles as login.html */
         :root {
@@ -306,6 +307,10 @@
                     <div class="form-error">{{ form.password2.errors[0] }}</div>
                 {% endif %}
             </div>
+
+            {% if not is_pull_request %}
+            <div class="cf-turnstile" data-sitekey="{{ config.CLOUDFLARE_TURNSTILE_SITE_KEY }}" data-theme="light"></div>
+            {% endif %}
 
             <button type="submit" class="auth-button">Create Account</button>
         </form>


### PR DESCRIPTION
This commit introduces Cloudflare Turnstile CAPTCHA verification to the /auth/login and /auth/register endpoints to enhance security.

Key changes:
- Adds Cloudflare Turnstile site and secret keys to the Flask app configuration.
- Implements a `verify_turnstile` helper function to validate the CAPTCHA response with Cloudflare's API.
- Includes a bypass mechanism in the verification function to skip the check in Render pull request environments (when `IS_PULL_REQUEST` is 'true'), allowing for seamless testing.
- Updates the login and register routes to perform the verification check and handle failures gracefully.
- Modifies the login and register HTML templates to conditionally render the Turnstile widget, hiding it in pull request environments to prevent display errors.